### PR TITLE
Fix galsim

### DIFF
--- a/bin/conda-lsst
+++ b/bin/conda-lsst
@@ -30,7 +30,7 @@ output_dir = os.path.join(root_dir, "recipes/generated")
 internal_products = set("python swig libevent flask twisted scons numpy protobuf matplotlib".split())
 
 # Products to skip alltogether (i.e., don't build, don't make a dependency)
-skip_products = set("anaconda afwdata sims_GalSimInterface GalSim".split())
+skip_products = set("anaconda afwdata".split())
 
 # Products that need to be prefixed with our prefix to avoid collisions
 # Products whose Conda name will _not_ be prefixed with out namespace prefix

--- a/patches/GalSim/rpath-fix.patch
+++ b/patches/GalSim/rpath-fix.patch
@@ -1,0 +1,21 @@
+diff --git a/../../../galsim-eupspkg.cfg.sh b/ups/eupspkg.cfg.sh
+index 8c0e8d9..644cd68 100644
+--- ups/eupspkg.cfg.sh
++++ ups/eupspkg.cfg.sh
+@@ -1,7 +1,16 @@
+ export SCONSFLAGS=$SCONSFLAGS" USE_UNKNOWN_VARS=true TMV_DIR="$TMV_DIR" PREFIX="$PREFIX" PYPREFIX="$PREFIX"/lib/python EXTRA_LIB_PATH="$TMV_DIR"/lib EXTRA_INCLUDE_PATH="$TMV_DIR"/include"
+ 
++# Work around the incorrect install name of Anaconda's libpython2.7.dylib (part 1/2)
++export DYLD_FALLBACK_LIBRARY_PATH="$CONDA_DEFAULT_ENV/lib"
++
+ install()
+ {
+     default_install
+     cp -r include $PREFIX/
++
++    if [[ $OSTYPE == darwin* ]]; then
++        # Work around the incorrect install name of Anaconda's libpython2.7.dylib (part 2/2)
++        echo "Fixing @rpath in _galsim.so"
++        install_name_tool -change libpython2.7.dylib @rpath/libpython2.7.dylib "$PREFIX"/lib/python/galsim/_galsim.so
++    fi
+ }

--- a/patches/lsst_sims/remove-galsim.patch
+++ b/patches/lsst_sims/remove-galsim.patch
@@ -1,8 +1,0 @@
---- ups/lsst_sims.table	2015-07-04 15:57:02.209058004 -0500
-+++ ups/lsst_sims.table	2015-07-04 15:57:15.819035812 -0500
-@@ -1,5 +1,4 @@
- setupRequired(sims_maf)
--setupRequired(sims_GalSimInterface)
- setupRequired(sims_catUtils)
- setupRequired(sims_catalogs_generation)
- setupRequired(sims_catalogs_measures)


### PR DESCRIPTION
This closes #10.

The fix has been inspired by https://github.com/GalSim-developers/GalSim/wiki/Building-GalSim-with-the-LSST-stack, but has been designed so as to avoid modifying any Anaconda binaries.
