### PR TITLE
rename binstar conda package to anaconda-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ This code is beta quality; it is expected to work on OS X and Linux.
 
 ## Prerequisites
 
-You need at least [Miniconda](conda.pydata.org/miniconda.html) with `conda-build`, `jinja2`, 
-`binstar`, `requests`, `sqlalchemy` packages installed, and the `requests_file` python
-module (install with `pip install requests_file`). For your convenience, there's a
-script, [./bin/bootstrap.sh](bin/bootstrap.sh), that when run:
+You need at least [Miniconda](conda.pydata.org/miniconda.html) with
+`conda-build`, `jinja2`, `anaconda-client` (provides `binstar`), `requests`,
+`sqlalchemy` packages installed, and the `requests_file` python module (install
+with `pip install requests_file`). For your convenience, there's a script,
+[./bin/bootstrap.sh](bin/bootstrap.sh), that when run:
 ```bash
 bash ./bin/bootstrap.sh
 ```

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -36,7 +36,7 @@ if [[ ! -f "$PWD/miniconda/.installed" ]]; then
 	# Install prerequisites
 	#
 	export PATH="$PWD/miniconda/bin:$PATH"
-	conda install conda-build jinja2 binstar requests sqlalchemy pip --yes
+	conda install conda-build jinja2 anaconda-client requests sqlalchemy pip --yes
 
 	pip install requests_file
 


### PR DESCRIPTION
Per this error message:

```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!
!!  The 'binstar' conda package has been renamed to 'anaconda-client'.
!!  Please run:
!!
!!    conda install anaconda-client
!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```
