### PR TITLE
remove stsci_distutils patch injecting pyton_d2to1 dep

### DIFF
--- a/patches/stsci_distutils/d2to1-dep.patch
+++ b/patches/stsci_distutils/d2to1-dep.patch
@@ -1,8 +1,0 @@
-diff --git ups/stsci_distutils.table ups/stsci_distutils.table
-index 5b7726b..bdb427d 100644
---- ups/stsci_distutils.table
-+++ ups/stsci_distutils.table
-@@ -1 +1,3 @@
-+setupRequired(python_d2to1)
-+
- envPrepend(PYTHONPATH, ${PRODUCT_DIR}/lib/python)


### PR DESCRIPTION
This patch fails to apply on recent builds (tested with b1852) as the
fix has since been merged upstream.  https://github.com/lsst/stsci_distutils/pull/1
