### PR TITLE
Support building repositories requiring git-lfs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@ This code is beta quality; it is expected to work on OS X and Linux.
 You need at least [Miniconda](conda.pydata.org/miniconda.html) with
 `conda-build`, `jinja2`, `requests`, and `sqlalchemy` packages installed, 
 as well as the `requests_file` python module (install
-with `pip install requests_file`). For your convenience, there's a script,
-[./bin/bootstrap.sh](bin/bootstrap.sh), that when run:
+with `pip install requests_file`). You will also need to build and
+install the `git-lfs` and `lsst-git-lfs-config` conda packages using
+the recipes found in `etc/recipes` directory. For your convenience,
+there's a script, [./bin/bootstrap.sh](bin/bootstrap.sh), that when run:
 ```bash
 bash ./bin/bootstrap.sh
 ```
-will install all of these for you into a subdirectory named `miniconda`.
+will install all of these for you. Miniconda will be installed into a
+subdirectory named `miniconda`.
 
 ## Generating Conda recipes, and building the packages
 

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -5,6 +5,8 @@
 
 set -e
 
+trap '{ test -f .bootstrap.msg && cat .bootstrap.msg; rm -f .bootstrap.msg; }' EXIT
+
 if hash conda 2>/dev/null; then
 	echo 'Detected existing conda on $PATH:'
 	echo
@@ -48,6 +50,21 @@ else
 	echo
 fi
 
+#
+# Add git-lfs support
+#
+export PATH="$PWD/miniconda/bin:$PATH"
+if ! conda list lsst-git-lfs-config >/dev/null; then
+	echo "Building and installing git-lfs and lsst-git-lfs-config. Patience please..."
+	echo
+
+	conda build etc/recipes/git-lfs				>>.bootstrap.msg 2>&1
+	conda build etc/recipes/lsst-git-lfs-config		>>.bootstrap.msg 2>&1
+
+	conda install -q --yes --use-local lsst-git-lfs-config	>>.bootstrap.msg 2>&1
+
+	rm -f .bootstrap.msg
+fi
 
 echo "Miniconda has been installed in $PWD/miniconda. Add it to your path:"
 echo

--- a/etc/config.yaml
+++ b/etc/config.yaml
@@ -149,6 +149,11 @@ dependencies:
   protobuf:
     run:   [ google-apputils ]
     build: [ google-apputils ]
+# FIXME: Once https://github.com/conda/conda-build/pull/843 is merged,
+#        auto-installing of lsst-git-lfs-config should be taken out of bootstrap.sh
+#        and dependencies should be injected here as follows:
+#  sims_maps:
+#    build: [ "recipe/lsst-git-lfs-config" ]
   "*":
     run:
       - "nomkl                         # [not osx]"

--- a/etc/recipes/git-lfs/build.sh
+++ b/etc/recipes/git-lfs/build.sh
@@ -1,3 +1,16 @@
 #!/bin/sh
 
-./install.sh
+# Install script, modified from the bundled install.sh
+# and changed so that it doesn't call 'git lfs install'
+# automatically (thus polluting the ~/.gitconfig of the
+# user building the package.
+#
+# git-lfs (de)initialization is now done pre-(un)link
+# scripts
+
+mkdir -p "$PREFIX/bin"
+
+rm -rf "$PREFIX"/bin/git-lfs*
+for g in git*; do
+	install $g "$PREFIX/bin/$g"
+done

--- a/etc/recipes/git-lfs/meta.yaml
+++ b/etc/recipes/git-lfs/meta.yaml
@@ -1,17 +1,17 @@
 package:
   name: git-lfs
-  version: 1.0.2
+  version: 1.1.2
 
 build:
   number: 0
 
 source:
-  fn: git-lfs-linux-amd64-1.0.2.tar.gz # [linux64]
-  url: https://github.com/github/git-lfs/releases/download/v1.0.2/git-lfs-linux-amd64-1.0.2.tar.gz # [linux64]
-  sha256: 3786850065dfd3c4aa9866b866ca620899b98fe3613392f3b56ac23a8cfa1307 # [linux64]
-  fn: git-lfs-darwin-amd64-1.0.2.tar.gz # [osx]
-  url: https://github.com/github/git-lfs/releases/download/v1.0.2/git-lfs-darwin-amd64-1.0.2.tar.gz # [osx]
-  sha256: d9c8a61f6d5961e9d7e976c4a50069d89039d65ac7058a715cc47ed6766d73ed # [osx]
+  fn: git-lfs-linux-amd64-1.1.2.tar.gz # [linux64]
+  url: https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-linux-amd64-1.1.2.tar.gz # [linux64]
+  sha256: 30cda2c559eb6a870bb0768be22ad21bc015b3519f66811a42b2652c126cce7f # [linux64]
+  fn: git-lfs-darwin-amd64-1.1.2.tar.gz # [osx]
+  url: https://github.com/github/git-lfs/releases/download/v1.1.2/git-lfs-darwin-amd64-1.1.2.tar.gz # [osx]
+  sha256: 13ebc4523a4793522ca5217ad6080965321bd0cc213cfdd222ac1f740abd5fea # [osx]
 
 requirements:
   run:

--- a/etc/recipes/git-lfs/post-link.sh
+++ b/etc/recipes/git-lfs/post-link.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Make sure the new environment is on our path
+export PATH="$PREFIX/bin:$PATH"
+
+#
+# Now add the filters to the *system* gitconfig file
+#
+git config --system --add "filter.lfs.clean" "git-lfs clean %f"
+git config --system --add "filter.lfs.smudge" "git-lfs smudge %f"
+git config --system --add "filter.lfs.required" "true"

--- a/etc/recipes/git-lfs/pre-unlink.sh
+++ b/etc/recipes/git-lfs/pre-unlink.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Make sure the new environment is on our path
+export PATH="$PREFIX/bin:$PATH"
+
+#
+# Remove git-lfs configs from the *system* .gitconfig file
+#
+git config --system --remove-section "filter.lfs"

--- a/etc/recipes/lsst-git-lfs-config/build.sh
+++ b/etc/recipes/lsst-git-lfs-config/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+
+#
+# Copy the list of LSST's LFS hosts to a well known location.
+# This file will be used by link/unlink scripts to add the proper
+# lines to the system gitconfig file (and generate the credentials
+# file).
+#
+
+mkdir -p "$PREFIX/etc"
+cp lfs-hosts.txt "$PREFIX/etc/lsst-git-lfs-hosts.txt"

--- a/etc/recipes/lsst-git-lfs-config/lfs-hosts.txt
+++ b/etc/recipes/lsst-git-lfs-config/lfs-hosts.txt
@@ -1,0 +1,3 @@
+lsst-sqre-prod-git-lfs.s3-us-west-2.amazonaws.com
+git-lfs.lsst.codes
+s3.lsst.codes.helper

--- a/etc/recipes/lsst-git-lfs-config/meta.yaml
+++ b/etc/recipes/lsst-git-lfs-config/meta.yaml
@@ -1,0 +1,26 @@
+#
+# To build a Conda package, run conda build as:
+#
+#    conda build .
+#
+
+package:
+  name: lsst-git-lfs-config
+  version: 1.0.0
+
+build:
+  number: 0
+  string: 0
+
+requirements:
+  build:
+    - git
+    - git-lfs
+
+  run:
+    - git
+    - git-lfs
+
+about:
+  license: GPLv2
+  summary: Metapackage to setup credentials for anonymous access to LSST git-lfs repositories

--- a/etc/recipes/lsst-git-lfs-config/post-link.sh
+++ b/etc/recipes/lsst-git-lfs-config/post-link.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -ex
+
+# NOTE: if you change $CREDENTIALS_FILE, update pre-unlink.sh with the new location
+CREDENTIALS_FILE="$PREFIX/etc/git-lfs-lsst-anonymous-credentials"
+
+# Make sure the new environment is on our path
+export PATH="$PREFIX/bin:$PATH"
+
+# Turn of git-lfs batch API (not supported by LSST's git-lfs servers)
+git config --system --add "lfs.batch" false
+
+# create the credentials cache, and point the credentials helper to the cache
+# the cache has empty u/p, enabling anonymous access
+mkdir -p "$PREFIX/etc"
+rm -f "$CREDENTIALS_FILE"
+
+for HOST in $(cat "$PREFIX/etc/lsst-git-lfs-hosts.txt"); do
+	# Tell git to look for credentials for this host in $CREDENTIALS_FILE
+	git config --system --add "credential.https://$HOST.helper" "store --file '$CREDENTIALS_FILE'"
+	
+	# Add a credential for anonymous access
+	echo "https://:@"$HOST >> "$CREDENTIALS_FILE"
+done

--- a/etc/recipes/lsst-git-lfs-config/pre-unlink.sh
+++ b/etc/recipes/lsst-git-lfs-config/pre-unlink.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+# NOTE: if you change $CREDENTIALS_FILE, update post-link.sh with the new location
+CREDENTIALS_FILE="$PREFIX/etc/git-lfs-lsst-anonymous-credentials"
+
+# Make sure the new environment is on our path
+export PATH="$PREFIX/bin:$PATH"
+
+# Reverse the actions of pre-link
+rm -f "$CREDENTIALS_FILE"
+
+for HOST in $(cat "$PREFIX/etc/lsst-git-lfs-hosts.txt"); do
+	git config --system --remove-section "credential.https://$HOST"
+done
+
+git config --system --unset "lfs.batch" false

--- a/etc/recipes/lsst-git-lfs-config/run_test.sh
+++ b/etc/recipes/lsst-git-lfs-config/run_test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cat "$PREFIX/etc/gitconfig"


### PR DESCRIPTION
Support building repositories requiring `git-lfs`. This is accomplished by providing a conda package for `git-lfs`, and also a conda package `lsst-git-lfs-config` with credentials configurations for the LSST `git-lfs` repositories. The recipes for those packages have been crafted to insert `git-lfs` configurations not into the user's `~/.gitconfig`, but into the "system" gitconfig (which in conda is in `$ENV_PREFIX/etc/gitconfig`. This means conda git-lfs installs won't pollute the user's `.gitconfig` (and that installs in multiple conda environments can coexist).

The `bootstrap.sh` script has been updated to build and install `git-lfs` and `lsst-git-lfs-config` packages. If you're updating in place, rerun it to get these two installed. Once https://github.com/conda/conda-build/pull/843 is merged, this will stop being necessary (the recipes will pull them in via a build dependency).

Closes #57
